### PR TITLE
Fix typo in `tsconfig.json` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can find more [recommended TS config here](https://github.com/tsconfig/bases
 {
   "compilerOptions": {
     "target": "es2015",
-    "module: "commonjs"
+    "module": "commonjs"
   }
 }
 ```


### PR DESCRIPTION
Hi, I found a typo in the `tsconfig.json` example (it's an invalid JSON 😅 ).